### PR TITLE
Update pop2dir.py

### DIFF
--- a/bin/dmarc/pop2dir.py
+++ b/bin/dmarc/pop2dir.py
@@ -191,7 +191,7 @@ class Pop2Dir(object):
                         'save_reports_from_message_bodies: skipping content-type %s of msg uid %s' %
                         (ctype, uid))
             # mark msg as seen in KVstore
-            self.save_check_point(uid, msg)
+            self.save_check_point(uid.split()[1], msg)
         return filelist
 
     def check_eligible_mimetype(self, ctype, uid):
@@ -248,7 +248,7 @@ class Pop2Dir(object):
         seen_uids = set()
         for uid in messages:
             key = "%s_%s_%s" % (self.opt_pop3_server,
-                                self.opt_global_account["username"], uid)
+                                self.opt_global_account["username"], uid.split()[1])
             if self.helper.get_check_point(key) is not None:
                 seen_uids.add(uid)
         new_uids = set(messages) - seen_uids


### PR DESCRIPTION
2 lines should be fixed by replacing just "uid" onto "uid.split()[1]":
- 194 (or 211 after applying my previous patch): the last line before "return filelist" in the "save_reports_from_message_bodies()" method;
- 251 (or 268 after applying my previous patch): line forming the "key" variable at the beginning of loop in the "filter_seen_messages()" method.
It fixes the issue https://github.com/jorritfolmer/TA-dmarc/issues/36